### PR TITLE
Support for non-linux OS'es

### DIFF
--- a/main.py
+++ b/main.py
@@ -181,7 +181,13 @@ def networker(factory, _reactor):
 
 def main():
     logging.info("Trying to find number of available cores")
-    avaliCPUs = len(os.sched_getaffinity(0))
+    try:
+        avaliCPUs = len(os.sched_getaffinity(0))
+    except AttributeError:
+        # Fix for windows, which doesnt support getaffinity
+        logging.warning("Falling back to multiprocessing cpu_count to calc cores. Most likely getaffinity is not supported on your OS")
+        avaliCPUs = multiprocessing.cpu_count()
+
     if avaliCPUs > 2:
         avaliCPUs = 2  # Force at least 2 workers, just in case only one core is available: one worker to do all the
         # major tasks and one to just take care of networking: THIS WILL BE LAGGY: VERY LAGGY


### PR DESCRIPTION
I have implemented a small change to the initial handler to allow it to be run on multiple platforms. Confirmed working on Windows.

Note: This change will get all system CPU's, not the usable ones, as some platforms do not support the getaffinity syscall.