### PR TITLE
Simple fix for logging (?)

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ from quarry.net import server
 from twisted.internet import reactor
 
 logging.basicConfig(format="[%(asctime)s - %(levelname)s - %(threadName)s] %(message)s", level=logging.DEBUG)
+logging.root.setLevel(logging.NOTSET)
 
 try:
     logging.info("Trying to initialize the Blackfire probe")


### PR DESCRIPTION
Sets the root level to be NOTSET, which appears to fix logging:

![image](https://user-images.githubusercontent.com/38318382/89730899-cec1ff00-da3a-11ea-803e-3fe6b09ee2ef.png)

Quite new to the logging library so this might not be the best way.