### PR TITLE
Fix accidental *maximum* of two workers

### DIFF
--- a/main.py
+++ b/main.py
@@ -200,7 +200,7 @@ def main():
             "your OS")
         avaliCPUs = multiprocessing.cpu_count()
 
-    if avaliCPUs > 2:
+    if avaliCPUs < 2:
         avaliCPUs = 2  # Force at least 2 workers, just in case only one core is available: one worker to do all the
         # major tasks and one to just take care of networking: THIS WILL BE LAGGY: VERY LAGGY
     logging.info("Found {0} cores available!".format(avaliCPUs))


### PR DESCRIPTION
The condition that attempts to enforce a minimum of two workers accidentally caps it at two workers.

`if CPU_count is *greater* than 2, set it to 2` was what it was lol