### PR TITLE
Parse releases.json for minecraft:brand data in Connection.py

### DIFF
--- a/classes/network/Connection.py
+++ b/classes/network/Connection.py
@@ -1,4 +1,5 @@
 import multiprocessing
+import json
 
 from multiprocessing.queues import Empty
 
@@ -15,6 +16,11 @@ from .versions.v578 import v1_15_2
 entity_id = 1
 QUEUE_SIZE = 100000
 
+with open('releases.json', 'r') as f:
+    release_info = json.load(f)
+
+for releases in release_info:
+    brand = (releases['mcpyBrand'])
 
 class PlayerNetwork(server.ServerProtocol):
 
@@ -70,7 +76,7 @@ class PlayerNetwork(server.ServerProtocol):
         # Send 'brand' packet
         self.make_packet_and_send(PacketType.PLUGIN_MESSAGE, {
             'channel': 'minecraft:brand',
-            'data': 'McPy/0.0.1-alpha',  # TODO Edit that
+            'data': brand,  # TODO Edit that
         })
         # Send 'difficulty' packet
         self.make_packet_and_send(PacketType.SERVER_DIFFICULTY, {

--- a/classes/network/Connection.py
+++ b/classes/network/Connection.py
@@ -20,7 +20,7 @@ with open('releases.json', 'r') as f:
     release_info = json.load(f)
 
 for releases in release_info:
-    brand = (releases['mcpyBrand'])
+    brand = "McPy/" + (releases['mcpyVersion'])
 
 class PlayerNetwork(server.ServerProtocol):
 

--- a/releases.json
+++ b/releases.json
@@ -3,6 +3,7 @@
     "mcpyVersion": "v0.0.0-alpha",
     "mcpyVendor": "The McPy team",
     "minecraftVersion": "1.15.2",
+    "mcpyBrand": "McPy/v0.0.0-alpha",
     "releaseDate": "09 August 2020",
     "downloadLink": "https://github.com/tazz4843/McPy/releases/download/v0.0.0-alpha/v0.0.0-alpha.zip",
     "md5sum": "e37b82ed03819c9d46e9fd7f6e90d0dd",

--- a/releases.json
+++ b/releases.json
@@ -3,7 +3,6 @@
     "mcpyVersion": "v0.0.0-alpha",
     "mcpyVendor": "The McPy team",
     "minecraftVersion": "1.15.2",
-    "mcpyBrand": "McPy/v0.0.0-alpha",
     "releaseDate": "09 August 2020",
     "downloadLink": "https://github.com/tazz4843/McPy/releases/download/v0.0.0-alpha/v0.0.0-alpha.zip",
     "md5sum": "e37b82ed03819c9d46e9fd7f6e90d0dd",


### PR DESCRIPTION
The Connection.py now parses the json data from releases.json to get the minecraft:brand data. This will make it easier when releasing a new version of McPy. Instead of going into Connections.py and manually hardcoding it, you can just go into releases.json and change the "mcpyVersion" data.